### PR TITLE
Replace urls with official woocomerce API client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,13 +10,12 @@ setup(
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_woocommerce"],
     install_requires=[
-        'unidecode==1.2.0',
         'attrs==18.1.0',
         'backoff==1.3.2',
         'python-dateutil==2.7.3',
-        'requests==2.20.0',
         "pendulum",
         'singer-python==5.0.15',
+        'woocommerce==3.0.0'
     ],
     entry_points="""
     [console_scripts]

--- a/tap_woocommerce/api_wrapper.py
+++ b/tap_woocommerce/api_wrapper.py
@@ -1,0 +1,47 @@
+from typing import final
+from singer import utils
+import backoff
+import requests
+import json
+import singer.metrics as metrics
+import singer
+from woocommerce import API
+
+def _giveup(exc):
+    return exc.response is not None \
+        and 400 <= exc.response.status_code < 500 \
+        and exc.response.status_code != 429
+
+class ApiWrapper:
+    def __init__(self, url, consumer_key, consumer_secret, **kwargs):
+        self._logger = singer.get_logger()
+        self._wcApi = API(url, consumer_key, consumer_secret)
+
+    @utils.backoff((backoff.expo,requests.exceptions.RequestException), _giveup)
+    @utils.ratelimit(20, 1)
+    def orders(self, params):
+        try:
+            self._logger.info("API orders start")
+            return self._get("orders", "orders", params=params)
+        finally:
+            self._logger.info("API orders end")
+
+    def reports(self, date_min, date_max):
+        params={
+            "date_min": date_min,
+            "date_max": date_max
+        }
+        try:
+            self._logger.info("API reports start")
+            return self._get("reports", "reports/sales", params)
+        finally:
+            self._logger.info("API reports end")
+
+
+    def _get(self, stream_id, url, params):
+        with metrics.http_request_timer(stream_id) as timer:
+            resp = self._wcApi.get(url, params=params)
+            timer.tags[metrics.Tag.http_status_code] = resp.status_code
+            resp.raise_for_status()
+            return resp.json()
+

--- a/tap_woocommerce/schemas/orders.json
+++ b/tap_woocommerce/schemas/orders.json
@@ -33,7 +33,7 @@
       "type": ["null", "boolean"]
     },
     "refunds": {
-      "type": ["null", "object"],
+      "type": ["null", "object", "array"],
       "properties": {
         "id": {
           "type": ["null", "number"]


### PR DESCRIPTION
# Description of change
The problem:
Original authentication was only supported on HTTPS URLs
Solution:
Replace custom created URLs with official woocomerce API client

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
